### PR TITLE
fix: don't include env var in app

### DIFF
--- a/ssr/src/app.rs
+++ b/ssr/src/app.rs
@@ -54,7 +54,7 @@ pub fn App() -> impl IntoView {
 
     // fallible component in app startup
     // -> if environment variables are not defined, panic!
-    provide_context(EnvVarConfig::try_from_env());
+    // provide_context(EnvVarConfig::try_from_env());
 
     provide_context(SearchCtx::default());
     provide_context(SearchListResults::default());


### PR DESCRIPTION
deployment vars not to be available in leptos components.